### PR TITLE
My take on CategoricalVariable

### DIFF
--- a/src/CommonDataModel.jl
+++ b/src/CommonDataModel.jl
@@ -54,7 +54,8 @@ import Statistics:
 
 import CategoricalArrays: 
     CategoricalValue,
-    CategoricalArray
+    CategoricalArray,
+    CategoricalPool
 
 
 include("CatArrays.jl")

--- a/src/categoricalvariable.jl
+++ b/src/categoricalvariable.jl
@@ -1,65 +1,54 @@
+import DataStructures.OrderedCollections as OC
 
+# A variable of raw integer codes (`data`), together with the pool of category
+# labels and the raw-code -> ref lookup needed to present it as categorical
+# values. Both are computed once, here, from `mapping` — not on every
+# readblock!/getindex call, since readblock! in particular is called once per
+# chunk during a single array read.
+struct CategoricalVariable{V, N, R, TV <: AbstractVariable{R, N}} <: AbstractVariable{CategoricalValue{V, UInt32}, N}
+    data::TV
+    pool::CategoricalPool{V, UInt32}
+    coderefs::OC.OrderedDict{R, UInt32}
+end
 
-abstract type AbstractCategoricalVariable{V, N, R} <: AbstractVariable{CategoricalValue{V, UInt32}, N} end
+function CategoricalVariable(data::AbstractVariable{R, N}, mapping::AbstractDict{R, V}) where {R, N, V}
+    sorted_codes = sort(collect(keys(mapping)))
+    labels = V[mapping[c] for c in sorted_codes]
+    coderefs = OC.OrderedDict{R, UInt32}(c => i for (i, c) in enumerate(sorted_codes)) |> OC.freeze
+    pool = CategoricalPool{V, UInt32}(labels, false)
+    return CategoricalVariable{V, N, R, typeof(data)}(data, pool, coderefs)
+end
 
-# special methods for AbstractCategoricalVariable
-getvaluearray(a::AbstractCategoricalVariable)::AbstractVariable = throw(ArgumentError(
-    "getvaluearray is not implemented for $(typeof(a))."
-))
-getmapping(a::AbstractCategoricalVariable)::AbstractDict = throw(ArgumentError(
-    "getmapping is not implemented for $(typeof(a))."
-))
+# raw code -> category label, e.g. for looking up the label of a fill/missing value
+_label(a::CategoricalVariable, code) = a.pool.levels[a.coderefs[code]]
 
 # forward CommonDataModel.API
-name(v_category::AbstractCategoricalVariable) = name(getvaluearray(v_category))
-dimnames(v_category::AbstractCategoricalVariable) = dimnames(getvaluearray(v_category))
-dataset(v_category::AbstractCategoricalVariable) = dataset(getvaluearray(v_category))
-attribnames(v_category::AbstractCategoricalVariable) = attribnames(getvaluearray(v_category))
-attrib(v_category::AbstractCategoricalVariable, name::SymbolOrString) = attrib(getvaluearray(v_category),name)
+name(v_category::CategoricalVariable) = name(v_category.data)
+dimnames(v_category::CategoricalVariable) = dimnames(v_category.data)
+dataset(v_category::CategoricalVariable) = dataset(v_category.data)
+attribnames(v_category::CategoricalVariable) = attribnames(v_category.data)
+attrib(v_category::CategoricalVariable, name::SymbolOrString) = attrib(v_category.data, name)
 
 # forward other basic method
-Base.size(a::AbstractCategoricalVariable) = size(getvaluearray(a))
-DiskArrays.haschunks(a::AbstractCategoricalVariable) = DiskArrays.haschunks(getvaluearray(a))
-DiskArrays.eachchunk(a::AbstractCategoricalVariable) = DiskArrays.eachchunk(getvaluearray(a))
-Base.getindex(a::AbstractCategoricalVariable, name::SymbolOrString)  = getindex(getvaluearray(a),name)
-Base.getindex(a::AbstractCategoricalVariable, name::CFStdName)  = getindex(getvaluearray(a),name)
-
-# ---- internal helpers ---------------------------------------------------------
-
-function _sorted_labels(mapping::AbstractDict{R, V}) where {R, V}
-    sorted_codes = sort(collect(keys(mapping)))
-    return V[mapping[c] for c in sorted_codes]
-end
-
-function _build_categorical_array(
-    raw::AbstractArray{R, N}, mapping::AbstractDict{R, V}
-) where {V, N, R}
-    label_values = V[mapping[c] for c in raw]
-    return CategoricalArray{V, N, UInt32}(label_values; levels=_sorted_labels(mapping))
-end
-
-function _build_cat_value(code::R, mapping::AbstractDict{R, V}) where {R, V}
-    ca = CategoricalArray{V, 1, UInt32}(V[mapping[code]]; levels=_sorted_labels(mapping))
-    return ca[1]
-end
-
+Base.size(a::CategoricalVariable) = size(a.data)
+DiskArrays.haschunks(a::CategoricalVariable) = DiskArrays.haschunks(a.data)
+DiskArrays.eachchunk(a::CategoricalVariable) = DiskArrays.eachchunk(a.data)
+Base.getindex(a::CategoricalVariable, name::SymbolOrString) = getindex(a.data, name)
+Base.getindex(a::CategoricalVariable, name::CFStdName) = getindex(a.data, name)
 
 # ---- readblock! ---------------------------------------------------------
 
 function DiskArrays.readblock!(
-    a::AbstractCategoricalVariable{V, N, R}, aout, r::AbstractUnitRange...
+    a::CategoricalVariable{V, N, R}, aout, r::AbstractUnitRange...
 ) where {V, N, R}
-    raw = Array{R}(undef, length.(r)...)
-    DiskArrays.readblock!(getvaluearray(a), raw, r...)
-    ca = _build_categorical_array(raw, getmapping(a))
-    for i in eachindex(aout, ca)
-        aout[i] = ca[i]
+    broadcast!(aout, a.data[r...]) do x
+        CategoricalValue{V, UInt32}(a.pool, a.coderefs[x])
     end
-    return ca
+    return aout
 end
 
 function DiskArrays.writeblock!(
-    ::AbstractCategoricalVariable, ::Any, r::AbstractUnitRange...
+    ::CategoricalVariable, ::Any, r::AbstractUnitRange...
 )
     throw(ArgumentError(
         "Writing to a categorical CF variable is not supported yet."
@@ -72,77 +61,73 @@ end
 
 # Scalar indices (all Integer or CartesianIndex) → CategoricalValue
 function Base.getindex(
-    a::AbstractCategoricalVariable{V, N, R}, inds::Union{Integer, CartesianIndex}...
+    a::CategoricalVariable{V, N, R}, inds::Union{Integer, CartesianIndex}...
 ) where {V, N, R}
     @boundscheck checkbounds(a, inds...)
     DiskArrays.checkscalar(a, inds)
-    raw = getvaluearray(a)[inds...]
-    return _build_cat_value(raw, getmapping(a))
+    code = a.data[inds...]
+    return CategoricalValue{V, UInt32}(a.pool, a.coderefs[code])
 end
 
 # Array indices (ranges, colons, vectors, …) → CategoricalArray
-function Base.getindex(a::AbstractCategoricalVariable{V, N, R}, inds...) where {V, N, R}
+function Base.getindex(a::CategoricalVariable{V, N, R}, inds...) where {V, N, R}
     @boundscheck checkbounds(a, inds...)
-    raw = getvaluearray(a)[inds...]
-    return _build_categorical_array(raw, getmapping(a))
+    raw = a.data[inds...]
+    refs = UInt32[a.coderefs[c] for c in raw]
+    return CategoricalArray{V, ndims(raw)}(refs, a.pool)
 end
 
 # ---- CFVariable -----------------------------------------------------------------
-function _add_missing(data, mapping, f_m_vals)
-    pairs = [mapping[code] => missing for code in f_m_vals]
+function _add_missing(data, parent_var::CategoricalVariable, f_m_vals)
+    pairs = [_label(parent_var, code) => missing for code in f_m_vals]
     return isempty(pairs) ? data : replace(data, pairs...)
 end
- 
+
 # A custom `maskingvalue` (e.g. NaN, used for numeric CFVariables) does not
 # make sense for categorical data, so masked entries always become `missing`
 # here regardless of `maskingvalue(v)`.
 function DiskArrays.readblock!(
     v::CFVariable{T,N,TV}, aout, r::AbstractUnitRange...
-    ) where {T,N,TV<:AbstractCategoricalVariable}
+    ) where {T,N,TV<:CategoricalVariable}
 
-    parent_var = parent(v) ## 
+    parent_var = parent(v)
     data = similar(aout, eltype(parent_var))
     DiskArrays.readblock!(parent_var, data, r...)
 
-    aout .= _add_missing(data, 
-            getmapping(parent_var),
-        fill_and_missing_values(v))
-    
+    aout .= _add_missing(data, parent_var, fill_and_missing_values(v))
+
     return nothing
 end
 
 
 function Base.getindex(v::CFVariable{T,N,TV}, inds::Union{Integer, CartesianIndex}...
-    ) where {T,N,TV<:AbstractCategoricalVariable}
-    
+    ) where {T,N,TV<:CategoricalVariable}
+
     parent_var = parent(v)
     cat_val = Base.getindex(parent_var, inds...)
-    mapping = getmapping(parent_var)
-    is_missing = cat_val in (mapping[code] for code in fill_and_missing_values(v)) 
+    is_missing = cat_val in (_label(parent_var, code) for code in fill_and_missing_values(v))
     return is_missing ? missing : cat_val
 end
 
 function Base.getindex(v::CFVariable{T,N,TV}, inds...
-    ) where {T,N,TV<:AbstractCategoricalVariable}
-    
+    ) where {T,N,TV<:CategoricalVariable}
+
     parent_var = parent(v)
     data = Base.getindex(parent_var, inds...)
-    return _add_missing(data, 
-        getmapping(parent_var),
-        fill_and_missing_values(v))
+    return _add_missing(data, parent_var, fill_and_missing_values(v))
 end
 
 
 function Base.getindex(v::CFVariable{T,N,TV}, name::SymbolOrString
-    ) where {T,N,TV<:AbstractCategoricalVariable}
+    ) where {T,N,TV<:CategoricalVariable}
 
     parent_var = parent(v)
-    return getindex(getvaluearray(parent_var),name)
+    return getindex(parent_var.data, name)
 end
 
 function Base.getindex(v::CFVariable{T,N,TV}, name::CFStdName
-    ) where {T,N,TV<:AbstractCategoricalVariable}
+    ) where {T,N,TV<:CategoricalVariable}
 
     parent_var = parent(v)
-    return getindex(getvaluearray(parent_var),name)
+    return getindex(parent_var.data, name)
 end

--- a/test/test_categorical.jl
+++ b/test/test_categorical.jl
@@ -1,6 +1,6 @@
 using Test
-using CommonDataModel: 
-    AbstractCategoricalVariable,
+using CommonDataModel:
+    CategoricalVariable,
     AbstractVariable,
     MemoryDataset,
     defVar,
@@ -11,14 +11,6 @@ import CommonDataModel as CDM
 import DiskArrays
 import CategoricalArrays: CategoricalValue, CategoricalArray, unwrap, levels
 
-
-struct CategoricalVariable{V, N, R} <: AbstractCategoricalVariable{V, N, R}
-    data::AbstractVariable{R,N}
-    mapping::Dict{R,V}
-end
-
-CDM.getvaluearray(a::CategoricalVariable) = a.data
-CDM.getmapping(a::CategoricalVariable) = a.mapping
 
 const CLOUD_MAPPING = Dict{Int8, String}(
     Int8(0) => "Not processed",
@@ -48,12 +40,13 @@ function make_mock()
 end
 
 
-@testset "AbstractCategoricalVariable — eltype" begin
+@testset "CategoricalVariable — eltype" begin
     mock = make_mock()
     @test eltype(mock) == CategoricalValue{String, UInt32}
 end
 
-@testset "AbstractCategoricalVariable — collect" begin
+
+@testset "CategoricalVariable — collect" begin
     mock = make_mock()
     ca = collect(mock)
 
@@ -71,7 +64,7 @@ end
 end
 
 
-@testset "AbstractCategoricalVariable — array getindex" begin
+@testset "CategoricalVariable — array getindex" begin
     mock = make_mock()
 
     slice = mock[1:2, :]
@@ -90,7 +83,7 @@ end
 end
 
 
-@testset "AbstractCategoricalVariable — scalar getindex" begin
+@testset "CategoricalVariable — scalar getindex" begin
     mock = make_mock()
 
     val = mock[1, 1]
@@ -101,7 +94,7 @@ end
     @test unwrap(val2) == CLOUD_MAPPING[RAW_CODES[2, 4]]
 end
 
-@testset "AbstractCategoricalVariable — broadcasting" begin
+@testset "CategoricalVariable — broadcasting" begin
     mock = make_mock()
 
     # Broadcast a function element-wise: unwrap over all elements
@@ -111,7 +104,7 @@ end
 end
 
 
-@testset "AbstractCategoricalVariable — in" begin
+@testset "CategoricalVariable — in" begin
     mock = make_mock()
 
     @test "Cloud free" in mock


### PR DESCRIPTION
Tried a different implementation with a concrete CategoricalVariable type that contains the CategoricalPool and mapping, so these do not have to be re-recreated on every index.

Timing on a fairly large array, I get a 5x speedup for read:

```
const RAW_CODES = rand(Int8.(0:4), 10_000, 10_000)

function make_mock()
    ds = MemoryDataset(tempname(), "c")
    v = defVar(ds,"cloud",RAW_CODES,("lon","lat"), attrib = [
        "standard_name"             => "cloud_mask",
        "long_name"                 => "Cloud mask",
        "_FillValue"                => Int8(0)
        ])

    mock = CategoricalVariable(parent(v), CLOUD_MAPPING)
    return mock
end

mock = make_mock()
@time mock[:]
```

~1 second on this branch, ~5.5 seconds baseline